### PR TITLE
Focus energy now increases the critical hit chance, rather than lowering it

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -4877,13 +4877,13 @@ CriticalHitTest:
 	ld a, [de]
 	bit GettingPumped, a         ; test for focus energy
 	jr nz, .focusEnergyUsed      ; bug: using focus energy causes a shift to the right instead of left,
-	                             ; resulting in 1/4 the usual crit chance
+	                             ; resulting in 1/4 the usual crit chance [THIS IS FIXED]
 	sla b                        ; (effective (base speed/2)*2)
 	jr nc, .noFocusEnergyUsed
 	ld b, $ff                    ; cap at 255/256
 	jr .noFocusEnergyUsed
 .focusEnergyUsed
-	srl b
+	sla b                        ; Fixed focus energy bug and made it a left shift
 .noFocusEnergyUsed
 	ld hl, HighCriticalMoves     ; table of high critical hit moves
 .Loop


### PR DESCRIPTION
This bug made focus energy a hinderance in the original games, and we already have so few moves to work with - so lets get this focused bread